### PR TITLE
chore: Add Trivy and Bandit security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,61 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  trivy-scan:
+    name: Trivy Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          fi
+
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          exit-code: '0'
+
+      - name: Check for critical and high vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+        continue-on-error: true
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-security-scan'
+        continue-on-error: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trivy-scan:
-    name: Trivy Security Scan
+    name: Trivy Scan
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,7 +61,7 @@ jobs:
         continue-on-error: true
 
   bandit-scan:
-    name: Bandit Security Scan
+    name: Bandit Scan
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   trivy-scan:
-    name: Trivy Scan
+    name: Trivy
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,7 +61,7 @@ jobs:
         continue-on-error: true
 
   bandit-scan:
-    name: Bandit Scan
+    name: Bandit
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -52,10 +52,64 @@ jobs:
           exit-code: '1'
         continue-on-error: true
 
-      - name: Upload Trivy scan results to GitHub Security tab
+      - name: Upload Trivy scan results to Security tab
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-security-scan'
+        continue-on-error: true
+
+  bandit-scan:
+    name: Bandit Security Scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Create virtual environment
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+
+      - name: Install dependencies
+        run: |
+          source .venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Install Bandit
+        run: |
+          source .venv/bin/activate
+          pip install bandit[toml]
+
+      - name: Run Bandit Security Scan
+        uses: PyCQA/bandit-action@v1
+        with:
+          targets: "."
+
+      - name: Upload SARIF results to Security tab
+        if: github.ref == 'refs/heads/main'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: bandit-security-scan
+        continue-on-error: true
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bandit-sarif-results
+          path: results.sarif
+          retention-days: 30
         continue-on-error: true

--- a/offline/lmeval/requirements.txt
+++ b/offline/lmeval/requirements.txt
@@ -1,3 +1,3 @@
 huggingface_hub==0.34.1
-transformers==4.53.0.
+transformers==4.53.0
 datasets==3.1.0

--- a/offline/lmeval/requirements.txt
+++ b/offline/lmeval/requirements.txt
@@ -1,3 +1,3 @@
 huggingface_hub==0.34.1
-transformers==4.45.2
+transformers==4.53.0.
 datasets==3.1.0


### PR DESCRIPTION
- Adds workflow `security-scan.yml` 
    - Complete Trivy scan and upload artifacts
    - Complete Bandit scan and upload artifacts
- Bump transformers version to `4.53.0` to resolve existing vulnerabilities

Closes #11 

## Summary by Sourcery

Add an automated security-scan workflow using Trivy and Bandit and update the transformers library to mitigate vulnerabilities

New Features:
- Integrate Trivy and Bandit security scans into the CI pipeline

Build:
- Bump transformers dependency to 4.53.0 to address known vulnerabilities

CI:
- Add security-scan.yml workflow to run Trivy and Bandit scans on pull requests and pushes, with SARIF uploads and artifacts